### PR TITLE
fix(gradle): add google dependency in buildscript

### DIFF
--- a/lib/template/app/build.gradle
+++ b/lib/template/app/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'com.android.support:design:28.0.0'
-    implementation 'com.github.GoogleChrome:custom-tabs-client:b0d6c6e86d8046fa62135cebb7bc59d9feac9f89'
+    implementation 'com.github.GoogleChrome:custom-tabs-client:809a55cfa2abc074609a7639f9373a358baffc07'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'

--- a/lib/template/build.gradle
+++ b/lib/template/build.gradle
@@ -2,6 +2,7 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {


### PR DESCRIPTION
Google dependency is needed in buildscript task in order to build the app form android sdk with gradle